### PR TITLE
Force encoding to use `Encoding.default_external`.

### DIFF
--- a/lib/flavour_saver/runtime.rb
+++ b/lib/flavour_saver/runtime.rb
@@ -34,7 +34,7 @@ module FlavourSaver
         @privates = old_privates
         @context = old_context
       else
-        result = evaluate_node(@ast)
+        result = evaluate_node(@ast).to_s.force_encoding(Encoding::default_external)
       end
       result
     end


### PR DESCRIPTION
Fixes issue with 'incompatible character encodings: ASCII-8BIT and
UTF-8' error.
